### PR TITLE
Add pipe method

### DIFF
--- a/dcachefs/dcachefs.py
+++ b/dcachefs/dcachefs.py
@@ -263,10 +263,10 @@ class dCacheFileSystem(AsyncFileSystem):
 
     ls = sync_wrapper(_ls)
 
-    async def _cat_file(self, url, start=None, end=None, **kwargs):
-        webdav_url = self._get_webdav_url(url) or self.webdav_url
+    async def _cat_file(self, path, start=None, end=None, **kwargs):
+        webdav_url = self._get_webdav_url(path) or self.webdav_url
 
-        path = self._strip_protocol(url)
+        path = self._strip_protocol(path)
         url = URL(webdav_url) / path
         url = url.as_uri()
         request_kwargs = self.request_kwargs.copy()

--- a/dcachefs/dcachefs.py
+++ b/dcachefs/dcachefs.py
@@ -320,8 +320,17 @@ class dCacheFileSystem(AsyncFileSystem):
     async def _cp_file(self, path1, path2, **kwargs):
         raise NotImplementedError
 
-    async def _pipe_file(self, path1, path2, **kwargs):
-        raise NotImplementedError
+    async def _pipe_file(self, path, value, **kwargs):
+        webdav_url = self._get_webdav_url(path) or self.webdav_url
+
+        path = self._strip_protocol(path)
+        url = URL(webdav_url) / path
+        url = url.as_uri()
+        request_kwargs = self.request_kwargs.copy()
+        request_kwargs.update(kwargs)
+        session = await self.set_session()
+        async with session.put(url, data=value, **request_kwargs) as r:
+            r.raise_for_status()
 
     async def _mv(self, path1, path2, **kwargs):
         """

--- a/tests/test_dcachefs.py
+++ b/tests/test_dcachefs.py
@@ -198,6 +198,18 @@ def test_put(test_fs):
     assert test_fs.cat(remote_path) == bytes(_file_content, 'utf-8')
 
 
+def test_pipe_with_path_and_value(test_fs):
+    remote_path = '/test/testdir_2/file_uploaded.txt'
+    test_fs.pipe(path=remote_path, value=_file_content)
+    assert test_fs.cat(remote_path) == bytes(_file_content, 'utf-8')
+
+
+def test_pipe_with_dict(test_fs):
+    remote_path = '/test/testdir_2/file_uploaded.txt'
+    test_fs.pipe(path={remote_path: _file_content})
+    assert test_fs.cat(remote_path) == bytes(_file_content, 'utf-8')
+
+
 def test_read_remote_file(test_fs):
     # the default mode is binary, caching `block_size` bytes retrieved with a
     # single get request


### PR DESCRIPTION
Needed to implement the `get_mapper`, used to write zarr files